### PR TITLE
Separate loci and associate them with senses.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * [#82] Ability to specify convenience link on dictionary edit page (TTT no longer hardcoded)
 * [#37 (61)] Dictionary show page now shows full dictionary
 * [#139] Fixed missing button images
+* [#121] Loci now appear under their senses in lexeme view.
 
 ==Since 0.3.5==
 * Updated code for Rails 3.1 

--- a/app/controllers/lexemes_controller.rb
+++ b/app/controllers/lexemes_controller.rb
@@ -35,6 +35,11 @@ class LexemesController < ApplicationController
     }
     @external_addresses = @lexeme.dictionaries.collect(&:external_address).uniq.delete_if {|addy| addy.blank? }
 
+    @loci_for_sense = Hash.new
+    @lexeme.senses.each do |sense|
+      @loci_for_sense[sense] = Locus.attesting_sense(sense)
+    end
+
     respond_to do |format|
       format.html # show.html.erb
       format.xml  { render :xml => @lexeme }

--- a/app/models/locus.rb
+++ b/app/models/locus.rb
@@ -15,6 +15,13 @@ class Locus < ActiveRecord::Base
     :group => 'loci.id' }
   }
   
+  # Takes a sense or array of senses and returns all loci attesting them.
+  scope :attesting_sense, lambda {|sense|
+    { :joins => { :attestations => { :parses => :interpretations }},
+    :conditions => { :interpretations => { :sense_id => [*sense].collect(&:id) }},
+    :group => 'loci.id' }
+  }
+  
   scope :unattached, lambda {|lexeme|
     { :joins => "INNER JOIN attestations ON attestations.locus_id = loci.id INNER JOIN parses ON (parses.parsable_id = attestations.id AND parses.parsable_type = 'Attestation') LEFT OUTER JOIN interpretations ON interpretations.parse_id = parses.id",
      :conditions => { "interpretations.parse_id" => nil, "parses.parsed_form" => [*lexeme].collect(&:headword_forms) }

--- a/app/views/lexemes/show.html.erb
+++ b/app/views/lexemes/show.html.erb
@@ -10,10 +10,6 @@
 <% if @unattached > 0 %>
 	<i>Found <%= link_to h(pluralize(@unattached, "unattached parse")), :controller => "loci", :action => "unattached", :id => @lexeme %> pointing to a lexeme with this spelling.</i>
 <% end %>
-<% unless @loci.empty? %>
-<h3>Loci</h3>
-<%= render(:partial => "shared/locus", :collection => @loci) %>
-<% end %>
 
 <% for external_address in @external_addresses do %>
 <% for headword in @lexeme.initial_case_insensitive_headwords do %>

--- a/app/views/shared/_ref.html.erb
+++ b/app/views/shared/_ref.html.erb
@@ -1,5 +1,6 @@
 <%= if @loci.include?(ref) 
-			link_to "[#{greek_numeral(@loci.index(ref).next)}]", :anchor => "locus-#{ref.id}"
+sense = @loci_for_sense.keep_if{|k,v| v.include?(ref)}.keys.first
+		    link_to "[#{@lexeme.senses.index(sense).next}.#{greek_numeral(@loci_for_sense[sense].index(ref).next)}]", :anchor => "locus-#{ref.id}"
 		else
 			link_to "(#{greek_numeral(ref.id)})", ref
 		end %>

--- a/app/views/shared/_sense.html.erb
+++ b/app/views/shared/_sense.html.erb
@@ -10,4 +10,9 @@
 		</dl>
 		<% end %>
 	<% end %>
+    <% unless @loci_for_sense.try(:[], sense).blank? %>
+    <div class="loci">
+        <%= render(:partial => "shared/locus", :collection => @loci_for_sense[sense]) %>
+    </div>
+    <% end %>
 </li>

--- a/test/unit/locus_test.rb
+++ b/test/unit/locus_test.rb
@@ -24,4 +24,12 @@ class LocusTest < ActiveSupport::TestCase
   	
   	assert_equal loci.uniq, loci
   end
+  
+  test "attesting_sense" do
+    Sense.find_each do |sense|
+      attesting_sense_loci = Locus.attesting_sense(sense)
+      queried_loci = Locus.joins({:attestations => { :parses => :interpretations }}).where({:interpretations => {:sense_id => sense.id}}).uniq
+      assert (attesting_sense_loci - queried_loci).blank?
+    end
+  end
 end


### PR DESCRIPTION
Tried to separate constructions this way as well but the way they are currently pulled doesn't allow this.

Closes #121.
