### PR TITLE
New entry link from search

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+==Since 0.4.0==
+* [#78] New lexeme link always to be available on lexeme show and search pages
+
 ==Since 0.3.6==
 * [#142] Fixed failure of will_paginate on Locus search
 * [#141] Fixed issue where interpretations and loci wouldn't save

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
   gem 'bullet'
   gem 'missing_t', '~> 0.4.1'
   gem 'cucumber-rails', :require => false
+  gem 'capybara-webkit'
   gem 'database_cleaner'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.5.1)
+      capybara (>= 2.3.0, < 2.5.0)
+      json
     coffee-rails (3.1.1)
       coffee-script (>= 2.2.0)
       railties (~> 3.1.0)
@@ -153,6 +156,7 @@ PLATFORMS
 
 DEPENDENCIES
   bullet
+  capybara-webkit
   coffee-rails (~> 3.1.0)
   cucumber-rails
   database_cleaner

--- a/app/controllers/lexemes_controller.rb
+++ b/app/controllers/lexemes_controller.rb
@@ -56,22 +56,18 @@ class LexemesController < ApplicationController
     end
   end
 
+  # Find lexemes matching a given headword
+  # If :matchtype is Lexeme::CREATE or there are no results, return the new entry form.
+  # Otherwise, list any/all matching lexemes.
   def show_by_headword
     @lexeme = Lexeme.lookup_all_by_headword(params[:headword], :matchtype => params[:matchtype])
     
-    case @lexeme.length
-    when 0
+    if params[:matchtype] == Lexeme::CREATE || @lexeme.blank?
       flash[:notice] = t('lexemes.show_by_headword.new_lexeme_prompt_html', headword: params[:headword])
       flash[:headword] = params[:headword]
       respond_to do |format|
         format.html { redirect_to :action => 'new' }
         format.xml { render :nothing => true, :status => '404 Not Found' }
-      end
-    when 1
-      respond_to do |format|
-        format.html { redirect_to @lexeme.first }
-        format.xml { render :xml => @lexeme.first }
-        # lexeme display in XML is currently useless, btw
       end
     else
       respond_to do |format|

--- a/app/models/lexeme.rb
+++ b/app/models/lexeme.rb
@@ -14,9 +14,11 @@ class Lexeme < ActiveRecord::Base
   
   accepts_nested_attributes_for :dictionary_scopes, :dictionaries, :subentries, :headwords, :phonetic_forms, :allow_destroy => true, :reject_if => proc { |attributes| attributes.all? {|k,v| v.blank?} }
   
+  # Options for search field
+  CREATE = 'create_new'
   SUBSTRING = 'contains'
   EXACT = 'exact_match'
-  SEARCH_OPTIONS = [SUBSTRING, EXACT]
+  SEARCH_OPTIONS = [CREATE, SUBSTRING, EXACT]
 
   HASH_MAP_TO_PARSE = { :subentries => Subentry::HASH_MAP_TO_PARSE }
  

--- a/app/views/editor/index.html.erb
+++ b/app/views/editor/index.html.erb
@@ -2,7 +2,7 @@
     <div class="c50l"><div class="subcl">
         <h2><%= t(".tools") %></h2>
     
-        <%= form_tag({:controller => :lexemes, :action => :show_by_headword}, {:class => "yform"}) do %>
+        <%= form_tag({:controller => :lexemes, :action => :show_by_headword}, {:class => "yform", :id => "editor-lexeme-search"}) do %>
     
         <div class="subcolumns full">
             <div class="c66l"><div class="subcl type-text">

--- a/app/views/lexemes/show.html.erb
+++ b/app/views/lexemes/show.html.erb
@@ -32,5 +32,6 @@
 
 <%= safe_join([link_to(t('.edit'), edit_lexeme_path(@lexeme)), 
     link_to(t('.back_to_lexemes'), lexemes_path),
-    *@lexeme.dictionaries.collect {|d| link_to(t('.back_to_dictionary', dictionary: d.title), d)}],
+    *@lexeme.dictionaries.collect {|d| link_to(t('.back_to_dictionary', dictionary: d.title), d)},
+    link_to(t('lexemes.index.new_lexeme'), new_lexeme_path)],
     t('.link_separator', default: " | ")) %>

--- a/config/locales/models/lexeme/en.yml
+++ b/config/locales/models/lexeme/en.yml
@@ -2,6 +2,7 @@ en:
   lexeme:
     search:
       options:
+        - 'create new'
         - 'contains'
         - 'exact match'
     no_entry_linktext: "[No entry for <i>%{headword}</i> &times;%{count}]"

--- a/config/locales/models/lexeme/la.yml
+++ b/config/locales/models/lexeme/la.yml
@@ -2,6 +2,7 @@ la:
   lexeme:
     search:
       options:
+        - 'novum referre'
         - 'partim'
         - 'in toto'
     no_entry_linktext: '[Lemma <i>%{headword}</i> abest &times;%{count}]'

--- a/features/0.4.1/78 - New Entry Link.feature
+++ b/features/0.4.1/78 - New Entry Link.feature
@@ -1,0 +1,41 @@
+Feature: Creating a new entry from search results / lexeme view
+    There must always be a link to create a new entry from search 
+    results, as the results will not always be what was wanted.
+    
+    Background:
+        Given languages for testing
+          And a test dictionary
+    
+    Scenario: Search returns no results
+        Given there are 0 entries containing "quux"
+         When I search for "quux"
+         Then I should get a new entry page
+    
+    Scenario: Search returns one result
+        Given there are 1 entries containing "quux"
+         When I search for "quux"
+         Then I should be on a search results page with 1 results for "quux"
+          And I should see a link to create a new entry
+    
+    Scenario: Search returns multiple results
+        Given there are 3 entries containing "quux"
+         When I search for "quux"
+         Then I should be on a search results page with 3 results for "quux"
+          And I should see a link to create a new entry
+    
+    Scenario: Viewing a lexeme
+        Given there are 1 entries containing "quux"
+         When I am looking at the entry for "quux"
+         Then I should see a link to create a new entry
+    
+    Scenario: Performing a search
+        Given I am on the home page
+         Then I should see search options "create_new", "contains", and "exact_match"
+    
+    @javascript
+    Scenario: Wishing to create from search
+        Given I am on the home page
+          And there are 17 entries containing "quux"
+         When I select "create new" as my search option
+          And I enter "quux" into the query field
+         Then I should get a new entry page

--- a/features/0.4.1/78_steps.rb
+++ b/features/0.4.1/78_steps.rb
@@ -1,0 +1,54 @@
+Given(/^languages for testing$/) do
+  Language::DEFAULT.save
+end
+
+Given(/^a test dictionary$/) do
+  Dictionary.create(title: "Test", language: Language.first, source_language: Language.first, target_language: Language.first)
+end
+
+Given(/^there are (\d+) entries containing "(.*?)"$/) do |num, hw|
+  num.to_i.times do
+    lex = Lexeme.create 
+    headwords = lex.headwords
+    headwords.create(form: hw)
+  end
+end
+
+Given(/^I am on the home page$/) do
+  visit url_for(controller: :editor, action: :index, locale: I18n.default_locale, host: "127.0.0.1", port: 7787)
+end
+
+When(/^I search for "(.*?)"$/) do |term|
+  visit url_for(controller: :lexemes, action: :show_by_headword, headword: term)
+end
+
+When(/^I am looking at the entry for "(.*?)"$/) do |term|
+  visit url_for(controller: :lexemes, action: :show_by_headword, headword: term, as: :exact_lexeme)
+  click_link(I18n.t('lexemes.index.show'))
+end
+
+When(/^I select "(.*?)" as my search option$/) do |arg1|
+  page.select arg1, from: "matchtype"
+end
+
+When(/^I enter "(.*?)" into the query field$/) do |arg1|
+  page.fill_in I18n.t('editor.index.find_or_create_a_lexeme'), with: arg1
+  page.execute_script("$(\"editor-lexeme-search\").submit()");
+end
+
+Then(/^I should get a new entry page$/) do
+  assert_equal url_for(controller: :lexemes, action: :new, locale: I18n.default_locale, host: "127.0.0.1", port: 7787), current_url
+end
+
+Then(/^I should be on a search results page with (\d+) results for "(.*?)"$/) do |count, query|
+  page.assert_text(:visible, I18n.t('lexemes.matching.results', count: count.to_i, query: query))
+end
+
+Then(/^I should see a link to create a new entry$/) do
+  assert page.has_link?(I18n.t('lexemes.index.new_lexeme'))
+end
+
+Then(/^I should see search options "(.*?)", "(.*?)", and "(.*?)"$/) do |arg1, arg2, arg3|
+  assert_equal [arg1, arg2, arg3], Lexeme::SEARCH_OPTIONS
+  assert page.has_select?("matchtype", options: I18n.t('lexeme.search.options'))
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -56,3 +56,13 @@ end
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
+Capybara.javascript_driver = :webkit
+
+Capybara.run_server = true
+Capybara.server_port = 7787
+
+ApplicationController.class_eval do
+  def default_url_options(options = {})
+    { locale: I18n.locale, host: "127.0.0.1", port: 7787 }
+  end
+end


### PR DESCRIPTION
There must always be a link to create a new entry from search results, as the results will not always be what was wanted.

Also
- show as list of search results even when there's only one result
- allow 'create' directly, without having to go through the intermediary of a failed search
- show new lexeme link on lexeme show page

Closes #78.
