### PR TITLE
Language of the first etymon in an etymology shouldn't be listed if it's the same as the lexeme's

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 ==Since 0.4.0==
 * [#78] New lexeme link always to be available on lexeme show and search pages
+* [#85] Language of the first etymon in an etymology shouldn't be listed if it's the same as the lexeme's
 
 ==Since 0.3.6==
 * [#142] Fixed failure of will_paginate on Locus search

--- a/app/helpers/etymologies_helper.rb
+++ b/app/helpers/etymologies_helper.rb
@@ -127,12 +127,13 @@ module EtymologiesHelper
     # When 'etym' is an etymology set pre_note to 'Language etymon "gloss"' and recurse, 
     # using 'tree' as both the etymon and the tree, and using the etymon as the parent.
    when Etymology
+     initial_etymon_same_language = Language.lang_for(Lexeme.with_etymology(etym)) == etym.original_language unless parent
+
       if use_html
         language = content_tag :span, :class => "lexform-source-language" do
           html_escape etym.original_language.name
         end if etym.original_language unless
-          parent && parent.original_language == etym.original_language
-
+          (parent && parent.original_language == etym.original_language) || initial_etymon_same_language       
         etymon = content_tag :span, :class => "lexform-etymon" do
           wh etym.etymon
         end
@@ -143,7 +144,7 @@ module EtymologiesHelper
       else
         language = html_escape(etym.original_language.name) if 
           etym.original_language unless
-          parent && parent.original_language == etym.original_language
+          (parent && parent.original_language == etym.original_language) || initial_etymon_same_language
 
         etymon = sanitize etym.etymon
 

--- a/app/models/lexeme.rb
+++ b/app/models/lexeme.rb
@@ -96,6 +96,11 @@ class Lexeme < ActiveRecord::Base
 #    Lexeme.find(:all, :joins => HASH_MAP_TO_PARSE, :conditions => { :parses => { :parsable_id => parsables, :parsable_type => type }})
 #  end
 
+  # Return all lexemes described by etym
+  def self.with_etymology(etym)
+    joins(subentries: :etymologies).where(etymologies: {id: etym})
+  end
+
 	# Returns a list of headwords minus those that differ only in the casing
 	# of the first letter.  
 	def initial_case_insensitive_headwords

--- a/test/fixtures/etymologies.yml
+++ b/test/fixtures/etymologies.yml
@@ -1,6 +1,7 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 
 one:
+  id: 1
   etymon: MyString
   original_language_id: 1
   gloss: MyString

--- a/test/unit/helpers/etymologies_helper_test.rb
+++ b/test/unit/helpers/etymologies_helper_test.rb
@@ -91,4 +91,10 @@ class EtymologiesHelperTest < ActionView::TestCase
 		assert_equal html_escape("abdo, from ab + do; where ab is from apo, and where do is from dh3."),
 			wiki_format(subentries[:abdomen].etymologies.first)
 	end
+  
+  test "issue #85 - language shouldn't be named on first etymon if same as lexeme" do
+    # etymologies(:one) is 'Testwegian (zxx)' in the fixtures, as is the associated subentry
+    assert_equal etymologies(:one).original_language, etymologies(:one).subentries.first.try(:lexeme).try(:language)
+    assert_equal "#{ETYMON % "MyString"} #{GLOSS % "MyString"}.", html_format(etymologies(:one))
+  end
 end


### PR DESCRIPTION
Testwegian "foobar" having its etymology text being generated as "Testwegian foo + bar" should now just be given as "foo + bar".