### PR TITLE
Fixed an issue that prevented showing etymologies under unattached parses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * [#161] Fixed some issues where new subitems weren't being created
 * [#143] Fixed an issue where unattached parses were being underreported
 * [#88] Added options to work with loci on the lexeme show page
+* [#176] Fixed an issue that prevented showing etymologies under unattached parses
 
 ==Since 0.3.6==
 * [#142] Fixed failure of will_paginate on Locus search

--- a/app/models/etymology.rb
+++ b/app/models/etymology.rb
@@ -9,7 +9,7 @@ class Etymology < ActiveRecord::Base
   belongs_to :original_language, :class_name => "Language" # language of etymon
   validate :validate_sufficient_data
   translates :gloss
-  globalize_accessors :locales => (Language.all.collect(&:iso_639_code) | [I18n.default_locale])
+  globalize_accessors :locales => (Language.defined_language_codes | [I18n.default_locale])
   
   accepts_nested_attributes_for :notes, {:allow_destroy => true, :reject_if => proc { |attributes| attributes.all? {|k,v| v.blank?} }}
   accepts_nested_attributes_for :parses, :allow_destroy => true, :reject_if => proc {|attrs| Parse.rejectable?(attrs) }

--- a/app/models/gloss.rb
+++ b/app/models/gloss.rb
@@ -5,7 +5,7 @@ class Gloss < ActiveRecord::Base
   has_many :parses, :as => :parsable, :dependent => :destroy
   accepts_nested_attributes_for :parses, :allow_destroy => true, :reject_if => proc { |attributes| attributes.all? {|k,v| v.blank?} }
   translates :gloss, :fallbacks_for_empty_translations => true
-  globalize_accessors :locales => (Language.all.collect(&:iso_639_code) | [I18n.default_locale])  
+  globalize_accessors :locales => (Language.defined_language_codes | [I18n.default_locale])  
   
   scope :attesting, lambda {|parsables, type|
     joins(HASH_MAP_TO_PARSE).where({ :parses => { :parsable_id => parsables, :parsable_type => type }})

--- a/app/models/headword.rb
+++ b/app/models/headword.rb
@@ -3,7 +3,7 @@ class Headword < ActiveRecord::Base
   has_many :phonetic_forms, :through => :orthographs
   has_many :notes, as: :annotatable
   translates :form, :fallbacks_for_empty_translations => true
-  globalize_accessors :locales => (Language.all.collect(&:iso_639_code) | [I18n.default_locale])
+  globalize_accessors :locales => (Language.defined_language_codes | [I18n.default_locale])
   
   accepts_nested_attributes_for :phonetic_forms, :allow_destroy => true, :reject_if => proc { |attributes| attributes.all? {|k,v| v.blank?} }
   accepts_nested_attributes_for :notes, :allow_destroy => true, :reject_if => proc { |attributes| attributes.all? {|k,v| v.blank?} }

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -106,4 +106,9 @@ class Language < ActiveRecord::Base
   def language
     self
   end
+  
+  # Return an array of the language codes defined in the system.
+  def self.defined_language_codes
+    @defined_language_codes ||= all.collect(&:iso_639_code)
+  end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,6 +2,6 @@ class Note < ActiveRecord::Base
   belongs_to :language
   belongs_to :annotatable, :polymorphic => true
   translates :content, :fallbacks_for_empty_translations => true
-  globalize_accessors :locales => (Language.all.collect(&:iso_639_code) | [I18n.default_locale])
+  globalize_accessors :locales => (Language.defined_language_codes | [I18n.default_locale])
   
 end

--- a/app/models/parse.rb
+++ b/app/models/parse.rb
@@ -2,7 +2,7 @@ class Parse < ActiveRecord::Base
   has_many :interpretations
   belongs_to :parsable, :polymorphic => true
   translates :parsed_form, :fallbacks_for_empty_translations => true
-  globalize_accessors :locales => (Language.all.collect(&:iso_639_code) | [I18n.default_locale])  
+  globalize_accessors :locales => (Language.defined_language_codes | [I18n.default_locale])  
   
   
   # Returns parses without entries (determined by comparing parsed_form to headword forms).

--- a/app/models/phonetic_form.rb
+++ b/app/models/phonetic_form.rb
@@ -3,7 +3,7 @@ class PhoneticForm < ActiveRecord::Base
   has_many :orthographs
   has_many :headwords, :through => :orthographs
   translates :form, :fallbacks_for_empty_translations => true
-  globalize_accessors :locales => (Language.all.collect(&:iso_639_code) | [I18n.default_locale])
+  globalize_accessors :locales => (Language.defined_language_codes | [I18n.default_locale])
  
   validate :any_form_present?
   

--- a/app/models/sense.rb
+++ b/app/models/sense.rb
@@ -8,7 +8,7 @@ class Sense < ActiveRecord::Base
   has_many :notes, :as => :annotatable
   validate :validate_sufficient_data
   translates :definition, :fallbacks_for_empty_translations => true
-  globalize_accessors :locales => (Language.all.collect(&:iso_639_code) | [I18n.default_locale])
+  globalize_accessors :locales => (Language.defined_language_codes | [I18n.default_locale])
   
   accepts_nested_attributes_for :parses, :notes, :allow_destroy => true, :reject_if => proc { |attributes| attributes.all? {|k,v| v.blank?} }
   accepts_nested_attributes_for :glosses, :allow_destroy => true, :reject_if => proc {|attrs| Gloss.new(attrs.slice(Gloss.new.attribute_names)).invalid? }

--- a/app/models/subentry.rb
+++ b/app/models/subentry.rb
@@ -7,7 +7,7 @@ class Subentry < ActiveRecord::Base
   has_many :notes, :as => :annotatable
   validate :any_paradigm_present?
   translates :paradigm, :part_of_speech, :fallbacks_for_empty_translations => true
-  globalize_accessors :locales => (Language.all.collect(&:iso_639_code) | [I18n.default_locale])
+  globalize_accessors :locales => (Language.defined_language_codes | [I18n.default_locale])
   
   accepts_nested_attributes_for :senses, :notes, :etymotheses, :allow_destroy => true, :reject_if => proc { |attributes| attributes.all? {|k,v| v.blank?} }
   accepts_nested_attributes_for :etymologies, :allow_destroy => true, :reject_if => proc {|attrs| Etymology.rejectable?(attrs) }

--- a/app/views/shared/_lexeme.html.erb
+++ b/app/views/shared/_lexeme.html.erb
@@ -1,5 +1,5 @@
 <div class="lexform-entry">
 	<div class="lexform-headword" <%= lang_for(lexeme.headwords) %>><%= source(lexeme.language){ titleize_headwords_for lexeme } %></div>
 	<%= render :partial => "shared/headword", :collection => lexeme.headwords, :locals => {lexeme: lexeme} %>
-	<%= render :partial => "shared/subentry", :collection => lexeme.subentries, :locals => {lexeme: lexeme} %>
+	<%= render :partial => "shared/subentry", :collection => lexeme.subentries %>
 </div>

--- a/app/views/shared/_subentry.html.erb
+++ b/app/views/shared/_subentry.html.erb
@@ -1,6 +1,6 @@
 <div class="lexform-subentry"  <%= lang_for(subentry) %>>
 	<span class="lexform-paradigm">
-	  <%=wh source(lexeme.language){t('.principal_parts', paradigm: subentry.paradigm, default: "%{paradigm}.") || t('.no_principal_parts')} %>
+	  <%=wh source(Language.lang_for(subentry.lexeme)){t('.principal_parts', paradigm: subentry.paradigm, default: "%{paradigm}.") || t('.no_principal_parts')} %>
 	</span>
 	<!-- phonetic form was here, now in shared/headword -->
 	<span class="lexform-part-of-speech">

--- a/test/fixtures/etymologies.yml
+++ b/test/fixtures/etymologies.yml
@@ -74,3 +74,7 @@ second_etym:
   id: 60
   etymon: phobos
   original_language_id: 1
+  
+unattached:
+    id: 70
+    etymon: unattached

--- a/test/fixtures/etymotheses.yml
+++ b/test/fixtures/etymotheses.yml
@@ -19,3 +19,7 @@ for_chain_B2:
 for_chain_B3:
   subentry_id: 42
   etymology_id: 55
+
+unattached:
+    subentry_id: 1
+    etymology_id: 70

--- a/test/fixtures/parses.yml
+++ b/test/fixtures/parses.yml
@@ -93,3 +93,8 @@ for_chainB2:
   parsable_id: 53
   parsable_type: Etymology
   parsed_form: test2
+
+unattached:
+    parsable_type: Etymology
+    parsed_form: unattached
+    parsable_id: 70

--- a/test/functional/parsable_controller_test.rb
+++ b/test/functional/parsable_controller_test.rb
@@ -5,5 +5,12 @@ class ParsableControllerTest < ActionController::TestCase
     get :index
     assert_response :success
   end
+  
+  # 176: Loci#unattached is failing when the unattached is an etymology
+  # TODO: Test is not failing
+  test "should get unattached when it's an etymology" do
+    get :index, forms: ["unattached"]
 
+    assert_response :success
+  end
 end


### PR DESCRIPTION
The partial causing the error was failing if it wasn't being passed a lexeme explicitly.  Updated the partial to no longer require this.

Closes #176.

(Also cleaned up globalize_accessor calls to fetch language codes so they don't get called multiple times on a single request.)