### PR TITLE
Less nesty lexeme form

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 * [#93] Changed language chooser for etymologies from a dropdown to an autocomplete
 * [#92] Should be able to create a new language from the etymology form
 * [#100] Should be able to add note to a phonetic form
+* [#152] Replaced some borders on the lexeme edit form with whitespace to reduce nestiness
 
 ==Since 0.4.0==
 * [#78] New lexeme link always to be available on lexeme show and search pages

--- a/app/assets/stylesheets/1col_layout.css
+++ b/app/assets/stylesheets/1col_layout.css
@@ -225,3 +225,12 @@ div.autocomplete ul li {
   border-width: inherit;
   box-shadow: inherit;
 }
+
+fieldset fieldset {
+    /* !important !important !important because apparently this gets defined before the more basic files?
+       Opened #196 to rectify this later */
+    border: none !important;
+    margin-top: 1em !important;
+    margin-left: 1em !important;
+}
+

--- a/app/views/etymologies/_shortform.html.erb
+++ b/app/views/etymologies/_shortform.html.erb
@@ -8,14 +8,14 @@
             prompt: t('.language_name_or_code'),
             as: :language %>
     </div>
-    <dt>
+    <div class="type-text">
         <%= f.label :etymon %> 
         <%= f.text_field :etymon, size: width %>
-    </dt>
-    <dd>
+    </div>
+    <div class="type-text">
         <%= f.label :gloss %>
         <%= translatable_tag f, :text_field, :gloss, :vernacular, size: width %>
-    </dd>
+    </div>
 
     <%= list_children_with_option_to_add :parse, f, :remote => true, locals: { dictionaries: @dictionaries, form: :interlinear } %>
 			


### PR DESCRIPTION
removed borders on fieldsets that are children of fieldsets to reduce visual clutter.

still need to clean the thing up in general.

Closes #152.