### PR TITLE
#159 - deleting authorships from lexeme edit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * [#92] Should be able to create a new language from the etymology form
 * [#100] Should be able to add note to a phonetic form
 * [#152] Replaced some borders on the lexeme edit form with whitespace to reduce nestiness
+* [#159] Fixed an issue that prevented etymology sources from being edited or removed
 
 ==Since 0.4.0==
 * [#78] New lexeme link always to be available on lexeme show and search pages

--- a/app/models/etymothesis.rb
+++ b/app/models/etymothesis.rb
@@ -5,4 +5,10 @@ class Etymothesis < ActiveRecord::Base
   
   accepts_nested_attributes_for :etymology, allow_destroy: true, reject_if: proc {|attrs| Etymology.rejectable?(attrs) }
   accepts_nested_attributes_for :source, allow_destroy: false, reject_if: :all_blank
+
+  def source_attributes=(attributes)
+    if attributes['_destroy']
+      self.source_id = nil
+    end
+  end
 end

--- a/app/models/etymothesis.rb
+++ b/app/models/etymothesis.rb
@@ -6,6 +6,9 @@ class Etymothesis < ActiveRecord::Base
   accepts_nested_attributes_for :etymology, allow_destroy: true, reject_if: proc {|attrs| Etymology.rejectable?(attrs) }
   accepts_nested_attributes_for :source, allow_destroy: false, reject_if: :all_blank
 
+  # Dissociate the source 
+  # when hitting 'delete' from an etymology form
+  # instead of deleting it.
   def source_attributes=(attributes)
     if attributes['_destroy']
       self.source_id = nil

--- a/app/views/lexemes/_source.html.erb
+++ b/app/views/lexemes/_source.html.erb
@@ -1,4 +1,4 @@
-<% 
+<%=
 unless (f.object.try(:_destroy)) 
     render partial: 'sources/shortform', locals: { f: f } 
 end 

--- a/test/fixtures/etymologies.yml
+++ b/test/fixtures/etymologies.yml
@@ -78,3 +78,6 @@ second_etym:
 unattached:
     id: 70
     etymon: unattached
+    
+159_with_etymology_source:
+    etymon: word

--- a/test/fixtures/etymotheses.yml
+++ b/test/fixtures/etymotheses.yml
@@ -23,3 +23,8 @@ for_chain_B3:
 unattached:
     subentry_id: 1
     etymology_id: 70
+    
+159_with_etymology_source: 
+    subentry: 159_with_etymology_source
+    etymology: 159_with_etymology_source
+    source_id: 1

--- a/test/fixtures/lexemes.yml
+++ b/test/fixtures/lexemes.yml
@@ -37,3 +37,5 @@ for_chainA:
   id: 40
   
 179_in_multiple_language_dictionaries: {}
+
+159_with_etymology_source: {}

--- a/test/fixtures/subentries.yml
+++ b/test/fixtures/subentries.yml
@@ -63,3 +63,7 @@ for_chainB2:
     id: 50
     lexeme: 179_in_multiple_language_dictionaries
     part_of_speech: "v."
+    
+159_with_etymology_source:
+    lexeme: 159_with_etymology_source
+    part_of_speech: "word"

--- a/test/functional/lexemes_controller_test.rb
+++ b/test/functional/lexemes_controller_test.rb
@@ -208,21 +208,23 @@ class LexemesControllerTest < ActionController::TestCase
   test "should handle etymology sources in edit form correctly" do
     lexeme = lexemes(:"159_with_etymology_source")
     subentry = lexeme.subentries.first
+    subentry_count = lexeme.subentries.count
     etymothesis = subentry.etymotheses.first
+    etymo_count = subentry.etymotheses.count
     source = etymothesis.source
 
     get :edit, id: lexeme.id
     
     # Make sure the source section is shown
     # Also check number of subentries as error in update hash caused duplication
-    assert_select '.subentry', 1 
-    assert_select '.etymothesis .source', 1
+    assert_select '.subentry', subentry_count
+    assert_select '.etymothesis .source', etymo_count
     
     # Make sure that it doesn't actually delete the source
 	  assert_no_difference('Source.count') do
       put :update, id: lexeme.id, commit: I18n.t('lexemes.form.save_and_continue_editing'), lexeme: lexeme
-      assert_select '.subentry', 1
-      assert_select '.etymothesis .source', 1
+      assert_select '.subentry', subentry_count
+      assert_select '.etymothesis .source', etymo_count
 
       put :update, id: lexeme.id, commit: I18n.t('lexemes.form.save_and_continue_editing'),
         lexeme:
@@ -247,8 +249,8 @@ class LexemesControllerTest < ActionController::TestCase
           }
 
       # Make sure it's no longer associated with the lexeme
-      assert_select '.subentry', 1
-      assert_select '.etymothesis .source', 0
+      assert_select '.subentry', subentry_count
+      assert_select '.etymothesis .source', etymo_count.pred
     end
   end
 end

--- a/test/functional/lexemes_controller_test.rb
+++ b/test/functional/lexemes_controller_test.rb
@@ -215,7 +215,6 @@ class LexemesControllerTest < ActionController::TestCase
     # Make sure the section is shown
     assert_select '.source'
     
-    p etymothesis.inspect
     # Make sure that it doesn't actually delete the source
 	  assert_no_difference('Source.count') do
       put :update, id: lexeme.id, 
@@ -223,18 +222,14 @@ class LexemesControllerTest < ActionController::TestCase
           { subentries_attributes: { subentry.id =>
             { etymotheses_attributes: { etymothesis.id =>
               { source_attributes:
-                { id: source.id,
+                { authorship_attributes:
+                  { id: source.authorship_id
+                  },
                   pointer: source.pointer,
-                  authorship_id: source.authorship_id,
                   _destroy: 1 }}}}}}
-
-                  p etymothesis.inspect
-#          get :edit, id: lexeme.id
-#          puts @response.body
 
       # Make sure it's no longer associated with the lexeme
       assert_select '.source', 0
-      assert_nil etymothesis.source_id 
     end
   end
 end

--- a/test/functional/lexemes_controller_test.rb
+++ b/test/functional/lexemes_controller_test.rb
@@ -201,4 +201,40 @@ class LexemesControllerTest < ActionController::TestCase
     
     assert_select 'span[id$=search-indicator]'
   end
+  
+  # 159: [Failure to delete etymology sources in the lexeme edit form]
+  # Several underlying issues, including failure to *show* them at all
+  test "should handle etymology sources in edit form correctly" do
+    lexeme = lexemes(:"159_with_etymology_source")
+    subentry = lexeme.subentries.first
+    etymothesis = subentry.etymotheses.first
+    source = etymothesis.source
+
+    get :edit, id: lexeme.id
+    
+    # Make sure the section is shown
+    assert_select '.source'
+    
+    p etymothesis.inspect
+    # Make sure that it doesn't actually delete the source
+	  assert_no_difference('Source.count') do
+      put :update, id: lexeme.id, 
+        lexeme:
+          { subentries_attributes: { subentry.id =>
+            { etymotheses_attributes: { etymothesis.id =>
+              { source_attributes:
+                { id: source.id,
+                  pointer: source.pointer,
+                  authorship_id: source.authorship_id,
+                  _destroy: 1 }}}}}}
+
+                  p etymothesis.inspect
+#          get :edit, id: lexeme.id
+#          puts @response.body
+
+      # Make sure it's no longer associated with the lexeme
+      assert_select '.source', 0
+      assert_nil etymothesis.source_id 
+    end
+  end
 end


### PR DESCRIPTION
(The original request was to delete, but it shouldn’t be deleted, just disassociated.)

Closes #159.