### PR TITLE
188 Headwords between lexeme show and edit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * [#100] Should be able to add note to a phonetic form
 * [#152] Replaced some borders on the lexeme edit form with whitespace to reduce nestiness
 * [#159] Fixed an issue that prevented etymology sources from being edited or removed
+* [#188] The lexeme edit form now shows all its existing data, not just associated dictionaries
 * [#192] Fixed an issue with adding multiple notes to an item
 
 ==Since 0.4.0==

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -268,9 +268,7 @@ module ApplicationHelper
       # we should add any language if it exists and isn't listed in @langs
       # (such as old data still using default locale, or if the dictionary 
       # has changed to one with a different language code)
-      languages |= form.object.translations.collect do |xlat|
-        Language.find_or_initialize_by_iso_639_code(xlat.locale.to_s)
-      end  
+      languages |= Language.of_translations_of(form.object)
           
       output = ActiveSupport::SafeBuffer.new
     

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -125,4 +125,12 @@ class Language < ActiveRecord::Base
 
     Language.includes([:translations]).where(terms)
   end
+  
+  # Return all Languages given in an object's translations.
+  # Initializes new Language objects if none exists for a particular locale. 
+  def self.of_translations_of obj
+    return nil unless obj.respond_to? :translations
+    
+    obj.translations.collect {|xlat| find_or_initialize_by_iso_639_code(xlat.locale.to_s) }
+  end
 end

--- a/test/functional/lexemes_controller_test.rb
+++ b/test/functional/lexemes_controller_test.rb
@@ -276,4 +276,20 @@ class LexemesControllerTest < ActionController::TestCase
        assert_text I18n.t('lexemes.create.successful_create')
        assert_selector('.note', count: note_count + 2)
   end
+  
+  # 188: Show all languages for which there is data on edit form
+  test "Lexeme edit should show all languages with data" do
+    # control
+    get :edit, id: lexemes(:"179_in_multiple_language_dictionaries").id
+    assert_select '.headword .language-list li', /la/
+    
+    # change a headword locale
+    languages(:latin).iso_639_code = "xxx"
+    languages(:latin).save
+    
+    # should still show the 'la' headword, as well as the 'xxx' prompt
+    get :edit, id: lexemes(:"179_in_multiple_language_dictionaries").id
+    assert_select '.headword .language-list li', /la/
+    assert_select '.headword .language-list li', /xxx/
+  end
 end


### PR DESCRIPTION
The lexeme edit form now shows all its existing data, not just associated dictionaries.

Closes #188.