### PR TITLE
Language/sort order form fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * [#206] Fixed an issue where glosses couldn't be added to lexeme edit
 * [#215] Fixed an issue where specifying the language of an etymon would fail on save
 * [#209] Fixed an error when viewing a lexeme with a homograph in wiki format 
+* [#219] Fixed an error with the edit form for languages/sort orders
 
 ==Since 0.4.0==
 * [#78] New lexeme link always to be available on lexeme show and search pages

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -9,6 +9,3 @@
 		<label for="language_iso_639_code"><%= t(".code_prompt") %></label>
 		<%= language_form.text_field :iso_639_code %>
 	</div>
-
-  <%= list_children_with_option_to_add :sort_order, language_form, remote: true, limit_one: true %>
-

--- a/app/views/languages/_longform.html.erb
+++ b/app/views/languages/_longform.html.erb
@@ -1,0 +1,5 @@
+
+  <%= render partial: "form", locals: {language_form: language_form} %>
+
+  <%= list_children_with_option_to_add :sort_order, language_form, remote: true, limit_one: true %>
+

--- a/app/views/languages/edit.html.erb
+++ b/app/views/languages/edit.html.erb
@@ -2,10 +2,10 @@
 
 <%= form_for @language, { method: :put, action: 'update', html: {class: "yform"}} do |f| %>
 
-<%=	render(:partial => "form", :object => { :label => t('.update_button'), :action => 'update', :method => :put, :for_url => "/#{I18n.locale}/languages/#{@language.id}" }, locals: {language_form: f})) %>
+<%=	render(:partial => "longform", :object => { :label => t('.update_button'), :action => 'update', :method => :put, :for_url => "/#{I18n.locale}/languages/#{@language.id}" }, locals: {language_form: f}) %>
 
   <div class="type-button">
-    <%= f.submit t('.update') %>
+    <%= f.submit t('.update_button') %>
   </div>
 <% end %>
 

--- a/app/views/languages/new.html.erb
+++ b/app/views/languages/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @language, { method: :post, action: 'create', html: {:class => "yform"}} do |f| %>
 <%= # @action = "Create"
-		render(:partial => "form", :for_url => "/#{I18n.locale}/languages", locals: {language_form: f} }) 
+		render(:partial => "longform", :for_url => "/#{I18n.locale}/languages", locals: {language_form: f} }) 
 		%>
 
 


### PR DESCRIPTION
Fixes an error where lexeme edit failed when it tried to pull sort order form (which it shouldn’t really be showing anyway).

Closes #219.