### PR TITLE
Normalize whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Since 0.4.2
 * [#94] Added delete link to Lexeme show page
 * [#204] Fixed an issue where most wanted wasn't updating
+* [#175] Will now strip leading and trailing whitespace
 
 ## Since 0.4.1
 * [#89] Lexeme form now arranges etymology horizontally instead of by nesting

--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,4 @@ end
 
 gem 'prototype-rails'
 gem 'multi_json'
+gem 'strip_attributes'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.7)
     sqlite3 (1.3.7-x86-mingw32)
+    strip_attributes (1.8.0)
+      activemodel (>= 3.0, < 6.0)
     test-unit (2.5.5)
     thor (0.14.6)
     tilt (1.3.3)
@@ -169,6 +171,7 @@ DEPENDENCIES
   ruby-prof
   sass-rails (~> 3.1.0)
   sqlite3
+  strip_attributes
   test-unit
   uglifier
   will_paginate (~> 3.0.0)

--- a/lib/utility_functions/utility_functions.rb
+++ b/lib/utility_functions/utility_functions.rb
@@ -16,3 +16,9 @@ class Array
     to_sentence(connectors)
   end
 end
+
+# Strip_attributes gem will strip leading/trailing whitespace from 
+# translated attributes.
+Globalize::ActiveRecord::Translation.class_eval do
+  strip_attributes
+end


### PR DESCRIPTION
strip_attributes gem to strip leading and trailing spaces.

Closes #175.