### PR TITLE
Redirect for deleted lexemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#204] Fixed an issue where most wanted wasn't updating
 * [#175] Will now strip leading and trailing whitespace
 * [#212] Fixed an issue where principal parts and pronunciation were missing from lexeme index
+* [#95] Deleting a lexeme should now return you to the page you were on, when practicable
 
 ## Since 0.4.1
 * [#89] Lexeme form now arranges etymology horizontally instead of by nesting

--- a/app/controllers/lexemes_controller.rb
+++ b/app/controllers/lexemes_controller.rb
@@ -197,9 +197,15 @@ class LexemesController < ApplicationController
   def destroy
     @lexeme = Lexeme.find(params[:id])
     @lexeme.destroy
-
+    
+    # Redirect to referer if there is one and if it's not the lexeme link
+    # Otherwise send to main lexemes_url
+    redirect_target = request.env["HTTP_REFERER"].blank? || 
+      request.env["HTTP_REFERER"] == request.env["REQUEST_URI"] ? 
+      lexemes_url : request.env["HTTP_REFERER"]
+    
     respond_to do |format|
-      format.html { redirect_to(lexemes_url) }
+      format.html { redirect_to(redirect_target) }
       format.xml  { head :ok }
     end
   end


### PR DESCRIPTION
Redirect to HTTP referer if there is one and it isn’t the deleted lexeme.

Closes #95.